### PR TITLE
update to v5

### DIFF
--- a/bg1re/bg1re.readme.english.txt
+++ b/bg1re/bg1re.readme.english.txt
@@ -1380,6 +1380,7 @@ If your game supports access to BG1 Duke Palace after Sarevok's death, the quest
 -"Scar's Return": Duke Eltan will now recognize whether the player brought Scar's body or only told about its whereabouts for the later quest status.
 -"Scar's Return": compatibility added with EBG1's Duke Eltan component
 -"Scar's Return": compatibility added with Transitions' Duke Eltan components
+-"Scar's Return": Duke Eltan will talk about Scar's murder but quest will not trigger if PC wasn't in Scar's quarters and doesn't know the ale mug
 -"Necromancer's Trouble": Mourning mom will use all dialogue states
 
 Version 4.2:

--- a/bg1re/bg1re.readme.english.txt
+++ b/bg1re/bg1re.readme.english.txt
@@ -1,6 +1,6 @@
 		Baldur's Gate Romantic Encounters Modification (BG1RE)
 	for BG1 (with TotSC), BG1Tutu v4, EasyTutu, BGT, BG:EE, and EET
-					Version 4.2
+					
 				A Gibberlings Three Mod
 				http://www.gibberlings3.net
 
@@ -977,7 +977,9 @@ Ever felt bad about Scar's murder? Ever wanted to look for his vanished body, cu
 Note: You can also prepare Scar's resurrection without having to deal with his body at all. Just tell the appropriate persons that Duke Eltan should be informed, and it will happen behind the scenes. This is for people who do not like the thought of corpses in their back pack.
 
 
-More spoilers: *** After talking to Duke Eltan about Scar's murder, go search for Donnerjan's Second Hand Shop (he is in a public area in Baldur's Gate City), buy the right item from him (the PC will remember), and talk to him again. From there, the PC has to talk to several different ex-servants of the Flaming Fist, each giving the needed next step until finally the trail can be followed to locate Scar's body. Duke Eltan has to be talked to several times about it. After Duke Eltan has told about Scar's funeral, a timer of one day will start. After this timer run out and the PC unmasked Sarevok in the Palace (before following him into the maze), Scar can be met in the Harbor Master's Building. Talk to Duke Eltan again to trigger the meeting. ***
+More spoilers: *** After talking to Duke Eltan about Scar's murder, go search for Donnerjan's Second Hand Shop (he is in a public area in Baldur's Gate City), buy the right item from him (the PC will remember), and talk to him again. From there, the PC has to talk to several different ex-servants of the Flaming Fist, each giving the needed next step until finally the trail can be followed to locate Scar's body. Duke Eltan has to be talked to several times about it. After Duke Eltan has told about Scar's funeral, a timer of one day will start. After this timer run out and the PC at least unmasked Sarevok in the Palace, Scar can be met one last time. Talk to Duke Eltan again to trigger the meeting. 
+
+For games that leave you in the BG1 "world" after Sarevok's death and give access to the Palace, the parts or even the whole Scar Return quest can be played after Sarevok was killed, too. Duke Eltan will move into the Palace, and the last meeting with Scar will happen here, too. This is fully compatible with EndlessBG1's component "Duke Eltan Inside the Palace" if bg1re is installed after EBG1. ***
 
 
 
@@ -1272,7 +1274,7 @@ If you play it with the original BG, the mod is compatible with MotSC (= TWM)
 
 For compatibility, please stick to the install order:
 
-bg1npc project - bg1re - bg1ub - Jarl's Adventure Pack (v0.7)
+EBG1 - Transitions - bg1npc project - bg1re - bg1ub - Jarl's Adventure Pack (v0.7)
 
 ----------------
 VIII. Known Issues
@@ -1370,6 +1372,15 @@ DLC Merger 				https://forums.beamdog.com/discussion/71305/mod-dlc-merger-merge-
 ----------------
 XII. History
 ----------------
+
+Version 5.0:
+-Completed dialogue for "Scar's Return" (placeholder line in Duke Eltan's dialogue)
+-"Scar's Return" can now be finished after Sarevok's death: 
+If your game supports access to BG1 Duke Palace after Sarevok's death, the quest can be started and played in full while you are still in the "BG1 world". If you play SoD, the quest can be finished in SoD. Depending on the quest status, the quest will be shortened accordingly.
+-"Scar's Return": Duke Eltan will now recognize whether the player brought Scar's body or only told about its whereabouts for the later quest status.
+-"Scar's Return": compatibility added with EBG1's Duke Eltan component
+-"Scar's Return": compatibility added with Transitions' Duke Eltan components
+-"Necromancer's Trouble": Mourning mom will use all dialogue states
 
 Version 4.2:
 -Fixed Tutu install error for component "Duke Eltan's Spare Minute"

--- a/bg1re/eltan/c#eltan.d
+++ b/bg1re/eltan/c#eltan.d
@@ -161,7 +161,7 @@ END
 IF ~~ THEN scar_02
 SAY @52
 IF ~Global("RE1_ScarFlirt","GLOBAL",1)~ THEN %UNSOLVED_JOURNAL% @53 + eltan_00
-IF ~!Global("RE1_ScarFlirt","GLOBAL",1)~ THEN %SOLVED_JOURNAL% @309 + eltan_00
+IF ~!Global("RE1_ScarFlirt","GLOBAL",1)~ THEN DO ~SetGlobal("C#RE1_ScarRetrieval","GLOBAL",99)~ %SOLVED_JOURNAL% @309 + eltan_00
 END
 
 IF ~~ THEN heard_scar

--- a/bg1re/eltan/c#eltan.d
+++ b/bg1re/eltan/c#eltan.d
@@ -99,12 +99,12 @@ END
 
 IF ~~ THEN eltan_06
 SAY @31
-IF ~~ THEN + eltan_06_end
+IF ~~ THEN DO ~SetGlobal("C#RE1_ScarRetrieval","GLOBAL",11)~ + eltan_06_end
 END
 
 IF ~~ THEN eltan_06_receit
 SAY @32
-IF ~~ THEN + eltan_06_end
+IF ~~ THEN DO ~SetGlobal("C#RE1_ScarRetrieval","GLOBAL",10)~ + eltan_06_end
 END
 
 IF ~~ THEN eltan_06_end
@@ -116,7 +116,7 @@ IF ~~ THEN eltan_scarbody
 SAY @34
 = @35
 = @36
-IF ~~ THEN DO ~SetGlobal("C#RE1_ScarRetrieval","GLOBAL",11)~ + eltan_00
+IF ~~ THEN + eltan_00
 END
 
 IF ~~ THEN eltan_07
@@ -234,11 +234,13 @@ END
 
 /* in Ducal Palace, PC can ask about Scar's quest */
 
+/////
+/* this state block will only be inserted if ebg1 is not present. -> c#eltan_no_ebg1.d
 IF WEIGHT #-1
 ~Dead("Sarevok")
 Name("C#RE1ELT",Myself) //only if bg1re Duke Eltan is talking
 GlobalLT("C#RE1_ScarRetrieval","GLOBAL",16)~ intro_scarsreturn_after_sarevok
-SAY ~Introline yaddaydaddy.~
+SAY @322
 + ~PartyHasItem("c#re1sr5")~ + @1 /* ~I have here the body of Scar! I found him.~ */ DO ~TakePartyItem("c#re1sr5")~ + eltan_06_as
 + ~PartyHasItem("c#re1sr6")~ + @2 /* ~I have news about the body of Scar! I located it.~ */ DO ~TakePartyItem("c#re1sr6")~ + eltan_06_receit_as
 + ~Global("C#RE1_ScarRetrieval","GLOBAL",10)~ + @3 /* ~Did you get news about Scar's body yet?~ */ DO ~SetGlobal("C#RE1_ScarRetrieval","GLOBAL",12)~ + heard_scar_as
@@ -246,15 +248,17 @@ SAY ~Introline yaddaydaddy.~
 + ~Global("C#RE1_ScarRetrieval","GLOBAL",12)~ + @5 /*  ~Any news about the possible resurrection of Scar?~ */ + rising_scar_as
 ++ ~Good day to you.~ EXIT
 END
+*/
+/////
 
 IF ~~ THEN eltan_06_as
 SAY @31 /* ~The... Indeed, this is Scar's body! How in the name of the gods did you...~ */
-IF ~~ THEN + eltan_06_end_as
+IF ~~ THEN DO ~SetGlobal("C#RE1_ScarRetrieval","GLOBAL",11)~ + eltan_06_end_as
 END
 
 IF ~~ THEN eltan_06_receit_as
 SAY @32 /* ~A receipt? Are you saying, that... Yes, it has to be. How in the name of the gods did you...~ */
-IF ~~ THEN + eltan_06_end
+IF ~~ THEN DO ~SetGlobal("C#RE1_ScarRetrieval","GLOBAL",10)~ + eltan_06_end_as
 END
 
 IF ~~ THEN eltan_06_end_as
@@ -265,7 +269,7 @@ END
 IF ~~ THEN eltan_scarbody_as
 SAY @317
 = @35 /* ~And if it won't be possible, I will give him a decent burial. That is the least I can do for my old friend.~ */
-IF ~~ THEN DO ~SetGlobal("C#RE1_ScarRetrieval","GLOBAL",11)~ EXIT
+IF ~~ THEN EXIT
 END
 
 IF ~~ THEN heard_scar_as

--- a/bg1re/eltan/c#eltan_AR0108.baf
+++ b/bg1re/eltan/c#eltan_AR0108.baf
@@ -29,19 +29,6 @@ THEN
 		SetGlobal("C#RE1_SpawnEltan","MYAREA",1)
 END
 
-/* compatibility with EBG1: only one Duke Eltan shall remain */
-
-IF
-	Dead("Sarevok")
-	Exists("ELTAN") 
-	Exists("C#RE1ELT") 
-	Global("C#st_SpawnEltan","MYAREA",1)
-	Global("C#RE1_SpawnEltan","MYAREA",1)
-THEN
-	RESPONSE #100
-		ActionOverride("C#RE1ELT",DestroySelf())
-		SetGlobal("C#RE1_SpawnEltan","MYAREA",2)
-END
 
 /* bg1re only: Duke Eltan goes after Scar's Return Quest is finished */
 IF
@@ -51,5 +38,32 @@ IF
 THEN
 	RESPONSE #100
 		ActionOverride("C#RE1ELT",EscapeArea())
+		SetGlobal("C#RE1_SpawnEltan","MYAREA",2)
+END
+
+/* compatibility with EBG1: only one Duke Eltan shall remain */
+
+IF
+	Dead("Sarevok")
+	Exists("ELTAN") 
+	Exists("C#RE1ELT") 
+	Global("C#RE1_SpawnEltan","MYAREA",1)
+THEN
+	RESPONSE #100
+		ActionOverride("C#RE1ELT",DestroySelf())
+		SetGlobal("C#RE1_SpawnEltan","MYAREA",2)
+END
+
+
+/* compatibility with Transitions: only one Duke Eltan shall remain */
+
+IF
+	Dead("Sarevok")
+	Exists("BDELTAN") 
+	Exists("C#RE1ELT") 
+	Global("C#RE1_SpawnEltan","MYAREA",1)
+THEN
+	RESPONSE #100
+		ActionOverride("C#RE1ELT",DestroySelf())
 		SetGlobal("C#RE1_SpawnEltan","MYAREA",2)
 END

--- a/bg1re/eltan/c#eltan_no_ebg1.d
+++ b/bg1re/eltan/c#eltan_no_ebg1.d
@@ -1,0 +1,15 @@
+APPEND %tutu_var%%ELTANDLG_HARBORMASTER%
+IF WEIGHT #-1
+~Dead("Sarevok")
+//Name("C#RE1ELT",Myself) //only if bg1re Duke Eltan is talking
+GlobalLT("C#RE1_ScarRetrieval","GLOBAL",16)~ intro_scarsreturn_after_sarevok
+SAY @322
++ ~PartyHasItem("c#re1sr5")~ + @1 /* ~I have here the body of Scar! I found him.~ */ DO ~TakePartyItem("c#re1sr5")~ + eltan_06_as
++ ~PartyHasItem("c#re1sr6")~ + @2 /* ~I have news about the body of Scar! I located it.~ */ DO ~TakePartyItem("c#re1sr6")~ + eltan_06_receit_as
++ ~Global("C#RE1_ScarRetrieval","GLOBAL",10)~ + @3 /* ~Did you get news about Scar's body yet?~ */ DO ~SetGlobal("C#RE1_ScarRetrieval","GLOBAL",12)~ + heard_scar_as
++ ~Global("C#RE1_ScarRetrieval","GLOBAL",11)~ + @4 /* ~What is Scar's status?~ */ DO ~SetGlobal("C#RE1_ScarRetrieval","GLOBAL",12)~ + burying_scar_as
++ ~Global("C#RE1_ScarRetrieval","GLOBAL",12)~ + @5 /*  ~Any news about the possible resurrection of Scar?~ */ + rising_scar_as
+++ ~Good day to you.~ EXIT
+END
+
+END //APPEND

--- a/bg1re/eltan/c#eltan_sod_add.d
+++ b/bg1re/eltan/c#eltan_sod_add.d
@@ -1,0 +1,62 @@
+/* addition to Scar's Return quest so it can be solved in SoD, too */
+
+APPEND BDELTAN
+
+/* Scar's return, Ducal Palace */
+IF WEIGHT #-1
+~AreaCheck("bd0102")
+GlobalGT("C#RE1_ScarRetrieval","GLOBAL",9)
+GlobalLT("C#RE1_ScarRetrieval","GLOBAL",13)~ THEN scar_is_here_sod
+SAY @9 /* ~Ah, <CHARNAME>, there you are. You will be very surprised to see who has returned, in the truest meaning there is. Make yourself ready to meet an old friend. I know he would like to thank you.~ */
+IF ~~ THEN DO ~SetGlobal("C#RE1_ScarRetrieval","GLOBAL",13)
+ClearAllActions()
+      StartCutSceneMode()	
+	CutSceneId(Player1)    
+        CreateCreature("c#re1sr6",[444.491]%FACE_6%) 
+ActionOverride("c#re1sr6",DestroyItem("%tutu_var%sw1h02"))
+ActionOverride("c#re1sr6",DestroyItem("%tutu_var%shld04"))
+ActionOverride(Player1,Face(1))
+EndcutSceneMode()~ EXIT
+END
+
+IF WEIGHT #-1
+~AreaCheck("bd0102")
+Global("C#RE1_ScarRetrieval","GLOBAL",14)~ THEN scar_was_here_sod
+SAY @315
+IF ~~ THEN DO ~SetGlobal("C#RE1_ScarRetrieval","GLOBAL",16)~ EXIT
+END
+
+IF WEIGHT #-1
+~AreaCheck("bd0108") Global("C#RE1_ScarRetrieval","GLOBAL",15)~ THEN scar_was_attacked_sod
+SAY @316
+IF ~~ THEN DO ~SetGlobal("C#RE1_ScarRetrieval","GLOBAL",16)~ EXIT
+END
+
+END //APPEND
+
+/* 
+Global("C#RE1_ScarRetrieval","GLOBAL",9): PC got either receit or Scar's body
+quest is active but PC cannot give Scar's body for ~GlobalGT("C#RE1_ScarRetrieval","GLOBAL",0) 
+GlobalLT("C#RE1_ScarRetrieval","GLOBAL",9)~
+*/
+
+INTERJECT BDELTAN 10 c#lc_eltan_sod
+== BDELTAN IF ~GlobalGT("C#RE1_ScarRetrieval","GLOBAL",0) 
+GlobalLT("C#RE1_ScarRetrieval","GLOBAL",9)~ THEN @323 /* ~First, though, let me tell you that we finally found Scar. There were loyal servants who hid his body before Angelo and his minions could let it vanish for good.~ */
+= @318 /* ~We set the body to a well-earned rest, young friend. It's the only thing we could do. It was a decent burial, albeit somewhat hushed and not appropriate for the Second in Command of the Flaming Fist who served for so many years.~ */
+= @317 /* ~I promise you, loyal friend, that I will do anything in my power for my former Second in Command. If there is a way to raise him, I will have him raised.~ */
+END
+IF ~~ THEN DO ~EraseJournalEntry(@53)
+EraseJournalEntry(@59)
+EraseJournalEntry(@74)
+EraseJournalEntry(@86)
+EraseJournalEntry(@114)
+EraseJournalEntry(@134)
+EraseJournalEntry(@137)
+EraseJournalEntry(@145)
+EraseJournalEntry(@166)
+EraseJournalEntry(@198)
+EraseJournalEntry(@301)
+EraseJournalEntry(@309)
+EraseJournalEntry(@10000)~ SOLVED_JOURNAL @324 EXIT
+

--- a/bg1re/eltan/c#eltan_transition_add.d
+++ b/bg1re/eltan/c#eltan_transition_add.d
@@ -1,0 +1,111 @@
+EXTEND_BOTTOM BDELTAN %bdeltan_2054%
++ ~PartyHasItem("c#re1sr5")~ + @1 /* ~I have here the body of Scar! I found him.~ */ DO ~TakePartyItem("c#re1sr5")~ + eltan_06_as
++ ~PartyHasItem("c#re1sr6")~ + @2 /* ~I have news about the body of Scar! I located it.~ */ DO ~TakePartyItem("c#re1sr6")~ + eltan_06_receit_as
++ ~Global("C#RE1_ScarRetrieval","GLOBAL",10)~ + @3 /* ~Did you get news about Scar's body yet?~ */ DO ~SetGlobal("C#RE1_ScarRetrieval","GLOBAL",12)~ + heard_scar_as
++ ~Global("C#RE1_ScarRetrieval","GLOBAL",11)~ + @4 /* ~What is Scar's status?~ */ DO ~SetGlobal("C#RE1_ScarRetrieval","GLOBAL",12)~ + burying_scar_as
++ ~Global("C#RE1_ScarRetrieval","GLOBAL",12)~ + @5 /* ~Any news about the possible resurrection of Scar?~ */ + rising_scar_as
+END
+
+EXTEND_BOTTOM BDELTAN %bdeltan_2057%
++ ~PartyHasItem("c#re1sr5")~ + @1 /* ~I have here the body of Scar! I found him.~ */ DO ~TakePartyItem("c#re1sr5")~ + eltan_06_as
++ ~PartyHasItem("c#re1sr6")~ + @2 /* ~I have news about the body of Scar! I located it.~ */ DO ~TakePartyItem("c#re1sr6")~ + eltan_06_receit_as
++ ~Global("C#RE1_ScarRetrieval","GLOBAL",10)~ + @3 /* ~Did you get news about Scar's body yet?~ */ DO ~SetGlobal("C#RE1_ScarRetrieval","GLOBAL",12)~ + heard_scar_as
++ ~Global("C#RE1_ScarRetrieval","GLOBAL",11)~ + @4 /* ~What is Scar's status?~ */ DO ~SetGlobal("C#RE1_ScarRetrieval","GLOBAL",12)~ + burying_scar_as
++ ~Global("C#RE1_ScarRetrieval","GLOBAL",12)~ + @5 /* ~Any news about the possible resurrection of Scar?~ */ + rising_scar_as
+++ @7 EXIT
+END
+
+
+APPEND BDELTAN
+
+/* Duke Eltan gives quest after Sarevok's death - quest not started yet */
+
+IF WEIGHT #-1
+~AreaCheck("BG0108")
+Dead("Sarevok") Global("C#RE1_ScarRetrieval","GLOBAL",0)
+Global("RE1_ScarFlirt","GLOBAL",1)~ THEN scar_return
+SAY @311
+= @312 
+= @50 /* ~I have no idea where it is now. It was secured, <CHARNAME>, as was Lord Entar's, as soon as they were discovered. (in a bitter tone) This happened before Angelo betrayed us all, you must understand. We had hopes he could be revived again!~ */
+= @51 /* ~Lord Entar's was delivered to his family. But where Scar's body is now I cannot say. Some minions of Angelo's took it somewhere, I presume. There I was, thinking he was being treated by priests, when in reality this Angelo had already let Scar's body be dumped at some unknown place. They must have, because I heard them talking about giving his personal belongings to the servants!~ */
+= @313
+= @314
+IF ~~ THEN DO ~SetGlobal("C#RE1_ScarRetrieval","GLOBAL",1)~ UNSOLVED_JOURNAL @53   /* ~Scar's Body
+
+Eltan told me that Scar's body was lost the night he was murdered. If there is any chance for me to find him, I have to identify and gain the trust of his former loyal Flaming Fist servants - or search for leavings of his personal belongings that might turn up in the city!~ */ EXIT
+END
+
+/* Scar's return, Ducal Palace */
+IF WEIGHT #-1
+~AreaCheck("BG0108")
+!Global("#L_TalkedToDukes","GLOBAL",1)
+Dead("Sarevok") 
+GlobalTimerExpired("C#RE1_ScarRetrievalTimer","GLOBAL")
+Global("C#RE1_ScarRetrieval","GLOBAL",12)~ THEN scar_is_here_as
+SAY @9 /* ~Ah, <CHARNAME>, there you are. You will be very surprised to see who has returned, in the truest meaning there is. Make yourself ready to meet an old friend. I know he would like to thank you.~ */
+IF ~~ THEN DO ~SetGlobal("C#RE1_ScarRetrieval","GLOBAL",13)
+ClearAllActions()
+      StartCutSceneMode()	
+	CutSceneId(Player1)    
+        CreateCreature("c#re1sr6",[430.380]%FACE_12%) 
+ActionOverride("c#re1sr6",DestroyItem("%tutu_var%sw1h02"))
+ActionOverride("c#re1sr6",DestroyItem("%tutu_var%shld04"))
+ActionOverride(Player1,Face(1))
+EndcutSceneMode()~ EXIT
+END
+
+IF WEIGHT #-1
+~Dead("Sarevok") 
+!Global("#L_TalkedToDukes","GLOBAL",1)
+Global("C#RE1_ScarRetrieval","GLOBAL",14)
+AreaCheck("BG0108")~ THEN scar_was_here_as
+SAY @315
+IF ~~ THEN DO ~SetGlobal("C#RE1_ScarRetrieval","GLOBAL",16)~ EXIT
+END
+
+IF ~~ THEN eltan_06_as
+SAY @31 /* ~The... Indeed, this is Scar's body! How in the name of the gods did you...~ */
+IF ~~ THEN DO ~SetGlobal("C#RE1_ScarRetrieval","GLOBAL",11)~ + eltan_06_end_as
+END
+
+IF ~~ THEN eltan_06_receit_as
+SAY @32 /* ~A receipt? Are you saying, that... Yes, it has to be. How in the name of the gods did you...~ */
+IF ~~ THEN DO ~SetGlobal("C#RE1_ScarRetrieval","GLOBAL",10)~ + eltan_06_end_as
+END
+
+IF ~~ THEN eltan_06_end_as
+SAY @33 /* ~No matter. Quick, give it to me.~ */
+IF ~~ THEN + eltan_scarbody_as
+END
+
+IF ~~ THEN eltan_scarbody_as
+SAY @317
+= @35 /* ~And if it won't be possible, I will give him a decent burial. That is the least I can do for my old friend.~ */
+IF ~~ THEN EXIT
+END
+
+IF ~~ THEN heard_scar_as
+SAY @54 /* ~Yes, I did! Those loyal servants came here, and they... they brought what they found. How in the name of the gods did you find him? But it doesn't matter.~ */
+IF ~~ THEN + burying_scar_as
+END
+
+IF ~~ THEN burying_scar_as
+SAY @318
+= @56 /* ~There were some old friends, too. My Second in Command had good friends... Not the kind to raise their weapons and revenge what happened. But the kind who have great divine power, nonetheless. I... I have to admit I do not really believe in it, <CHARNAME>. But there is hope... a faint hope, that a resurrection can be done.~ */
+= @57 /* ~It involves great magic, the kind you need if the person is already lost. But I do not know anything for certain, and I certainly will not keep my hopes high. But I do believe that the person who stated this meant what he said.~ */
+= @58 /* ~Again, let me thank you from the bottom of my heart for this opportunity, <CHARNAME>. He -cough- he really didn't deserve rotting in a crate.~ */
+IF ~~ THEN DO ~%ERASEJOURNALENTRY_53% 
+%ERASEJOURNALENTRY_134%
+%ERASEJOURNALENTRY_137%
+%ERASEJOURNALENTRY_145%
+SetGlobalTimer("C#RE1_ScarRetrievalTimer","GLOBAL",ONE_DAY)~ %UNSOLVED_JOURNAL% @59 /* ~Scar's Body
+
+Duke Eltan mentioned friends of Scar who might have the divine powers to raise him. This sound promising...~ */ EXIT
+END
+
+IF ~~ THEN rising_scar_as
+SAY @319 
+IF ~~ THEN EXIT
+END
+
+END //APPEND

--- a/bg1re/necromancer/dialogues/necromancer.d
+++ b/bg1re/necromancer/dialogues/necromancer.d
@@ -53,7 +53,7 @@ SAY @16
 + ~PartyHasItem("c#q11tot")~ + @5 + mourning_mom_9
 ++ @10 + mourning_mom_10
 ++ @11 + mourning_mom_7
-++ @6 EXIT
+++ @6 + mourning_mom_6
 END
 
 

--- a/bg1re/setup-bg1re.tp2
+++ b/bg1re/setup-bg1re.tp2
@@ -7,7 +7,7 @@ BACKUP ~bg1re/backup~
 AUTHOR ~Please post in the G3 forum for help, refer to readme.~ //for bugreports
 
 //MODDER
-VERSION ~4.2~ 
+VERSION ~5.0 pre~ 
 
 README ~bg1re/bg1re.readme.%LANGUAGE%.txt~ ~bg1re/bg1re.readme.english.txt~
 
@@ -1217,7 +1217,9 @@ END
 
 END ELSE BEGIN
   COMPILE EVALUATE_BUFFER ~bg1re/eltan/c#eltan.d~
+			~bg1re/eltan/c#eltan_no_ebg1.d~ USING ~bg1re/tra/autotra/%LANGUAGE%/c#eltan.tra~
 END
+
 
 ACTION_IF GAME_IS ~tutu tutu_totsc bgt bgee eet~ THEN BEGIN
 
@@ -1286,7 +1288,31 @@ WRITE_EVALUATED_ASCII 0x248 ~C#RE1ELT~ #8   // Override script
 /* This is not an own component
 */
 
-ADD_JOURNAL TITLE (@302) @53 @59 @74 @86 @114 @134 @137 @145 @166 @198 @301 @309 @10000 USING ~bg1re/tra/autotra/%LANGUAGE%/c#eltan.tra~
+/* more content for SoD/EET so the Scar's Return quest can be finished in SoD: need more lines in BDELTAN.dlg */
+ACTION_IF GAME_INCLUDES ~sod~ THEN BEGIN
+  COMPILE EVALUATE_BUFFER ~bg1re/eltan/c#eltan_sod_add.d~
+	 USING ~bg1re/tra/autotra/%LANGUAGE%/c#eltan.tra~
+END
+
+/* compatibility with Transitions: need even more lines in BDELTAN.dlg so Scar's Return quest can be started after Sarevok's death. */
+ACTION_IF ((MOD_IS_INSTALLED ~transitions/setup-transitions.TP2~ "60")
+OR (MOD_IS_INSTALLED ~transitions/setup-transitions.TP2~ "61")
+OR (MOD_IS_INSTALLED ~transitions/setup-transitions.TP2~ "62")) THEN BEGIN 
+
+// Get state for BDELTAN %bdeltan_2054% 
+/* ~Hello again, <CHARNAME>.  Have you changed your mind?~ */
+OUTER_SET bdeltan_2054 = STATE_WHICH_SAYS 2054 IN ~transitions/languages/%s/DIALOGUES.TRA~ FROM ~BDELTAN~
+
+// Get state for BDELTAN %bdeltan_2057% 
+/* ~Greetings, <GABBER>.  It's a pleasure to see you again.~ */
+OUTER_SET bdeltan_2057 = STATE_WHICH_SAYS 2057 IN ~transitions/languages/%s/DIALOGUES.TRA~ FROM ~BDELTAN~
+
+COMPILE EVALUATE_BUFFER ~bg1re/eltan/c#eltan_transition_add.d~
+	 USING ~bg1re/tra/autotra/%LANGUAGE%/c#eltan.tra~
+
+END
+
+ADD_JOURNAL TITLE (@302) @53 @59 @74 @86 @114 @134 @137 @145 @166 @198 @301 @309 @324 @10000 USING ~bg1re/tra/autotra/%LANGUAGE%/c#eltan.tra~
 
 /* BGT: remove journal entries upon transition to BGII */
 ACTION_IF GAME_IS ~bgt~ THEN BEGIN

--- a/bg1re/setup-bg1re.tp2
+++ b/bg1re/setup-bg1re.tp2
@@ -7,7 +7,7 @@ BACKUP ~bg1re/backup~
 AUTHOR ~Please post in the G3 forum for help, refer to readme.~ //for bugreports
 
 //MODDER
-VERSION ~5.0 pre~ 
+VERSION ~5.0~ 
 
 README ~bg1re/bg1re.readme.%LANGUAGE%.txt~ ~bg1re/bg1re.readme.english.txt~
 

--- a/bg1re/tra/english/c#eltan.tra
+++ b/bg1re/tra/english/c#eltan.tra
@@ -345,7 +345,15 @@ Eltan told me that Scar's body was lost the night he was murdered. This is a sad
 @315   = ~Isn't it a miracle? Ah, <CHARNAME>. It is always good to have friends. Never forget this, young adventurer. I see Scar said his good-byes. Let us wish him the best. I tried to convince him to stay and regain his former position, bow this is over. But he deserves a quiet time. He's earned it.~
 @316   = ~Why you attacked a newly resurrected man will always be a miracle to me. Go, <CHARNAME>. Get out, and when they start calling you the saviour of this city, never forget how low you really stand.~
 @317   = ~I promise you, loyal friend, that I will do anything in my power for my former Second in Command. If there is a way to raise him, I will have him raised.~
-@318   = ~We set the body to a well-earned rest, young friend. It's the only thing we could do. It was a decent burial, albeit somewhat hushed and not appropriate for the Second in Command of the Flaming Fist who served for so many years. But there is a reason for this.~
+@318   = ~We set the body to a well-earned rest, young friend. It's the only thing we could do. It was a decent burial, albeit somewhat hushed and not appropriate for the Second in Command of the Flaming Fist who served for so many years.~
 @319   = ~We have to be patient. These things take time.~
 @320   = ~Forgive me, friend. I know I should have been braver, but I wasn't. I have the faint hope my action did some good, after all. That is all I can tell you, and I need to get back to work now.~
 @321   = ~Scar's body? Duke Eltan doesn't know where Scar's body is? So much for my efforts to hide it, seems I was too good at it. Do the gods think this is funny?~
+
+/* new for v4.3 */
+@322   = ~You saved us. You have the gratitude of the city.~
+@323   = ~First, though, let me tell you that we finally found Scar. There were loyal servants who hid his body before Angelo and his minions could let it vanish for good.~
+@324   = ~Scar's Body
+
+Eltan told me that Scar's body was found and put to rest.~
+@325   = ~Whether my former Second in Command will ever see the light of day again will be up to the gods, I wager... And we have pressing matters at hand.~

--- a/bg1re/tra/english/c#eltan.tra
+++ b/bg1re/tra/english/c#eltan.tra
@@ -339,7 +339,7 @@ Eltan told me that Scar's body was lost the night he was murdered. This is a sad
 
 /* new for v3.0 */
 @311   = ~<CHARNAME>, our savior! The city is in your debt.~ 
-@312   = ~There is one more thing I would seek your help with. I was told that you had friendly connections to my former Second in Command, Scar - you were seen visiting his private quarters so that is more than many can tell from themselves. You know already that he was murdered, and we would like to bury him appropriately. For this, we need Scar's body.~
+@312   = ~There is one more thing I would seek your help with. I was told that you had friendly connections to my former Second in Command, Scar - you were seen visiting his private quarters. That is more than many can say for themselves. You know already that he was murdered, and we would like to bury him appropriately. For this, we need Scar's body.~
 @313   = ~Angelo's minions won't tell us anything about it, so the only ones who might know about it would be the once loyal servants that were sent away that night. They are probably scattered all around the city, if they haven't fled out of it altogether.~
 @314   = ~Please find Scar's body, <CHARNAME>. I have lost my Second in Command and one of my most capable men, and I can't even give him a decent burial, because I don't know where his body is!~
 @315   = ~Isn't it a miracle? Ah, <CHARNAME>. It is always good to have friends. Never forget this, young adventurer. I see Scar said his good-byes. Let us wish him the best. I tried to convince him to stay and regain his former position, bow this is over. But he deserves a quiet time. He's earned it.~
@@ -350,7 +350,7 @@ Eltan told me that Scar's body was lost the night he was murdered. This is a sad
 @320   = ~Forgive me, friend. I know I should have been braver, but I wasn't. I have the faint hope my action did some good, after all. That is all I can tell you, and I need to get back to work now.~
 @321   = ~Scar's body? Duke Eltan doesn't know where Scar's body is? So much for my efforts to hide it, seems I was too good at it. Do the gods think this is funny?~
 
-/* new for v4.3 */
+/* new for v5.0 */
 @322   = ~You saved us. You have the gratitude of the city.~
 @323   = ~First, though, let me tell you that we finally found Scar. There were loyal servants who hid his body before Angelo and his minions could let it vanish for good.~
 @324   = ~Scar's Body


### PR DESCRIPTION
-Completed dialogue for "Scar's Return" (placeholder line in Duke Eltan's dialogue)
-"Scar's Return" can now be finished after Sarevok's death: 
If your game supports access to BG1 Duke Palace after Sarevok's death, the quest can be started and played in full while you are still in the "BG1 world". If you play SoD, the quest can be finished in SoD. Depending on the quest status, the quest will be shortened accordingly.
-"Scar's Return": Duke Eltan will now recognize whether the player brought Scar's body or only told about its whereabouts for the later quest status.
-"Scar's Return": compatibility added with EBG1's Duke Eltan component
-"Scar's Return": compatibility added with Transitions' Duke Eltan components
-"Scar's Return": Duke Eltan will talk about Scar's murder but quest will not trigger if PC wasn't in Scar's quarters and doesn't know the ale mug
-"Necromancer's Trouble": Mourning mom will use all dialogue states
