### PR TITLE
Dinner with Thalantyr fixes

### DIFF
--- a/bg1re/bg1re.readme.english.txt
+++ b/bg1re/bg1re.readme.english.txt
@@ -1384,6 +1384,10 @@ DLC Merger 				https://forums.beamdog.com/discussion/71305/mod-dlc-merger-merge-
 XII. History
 ----------------
 
+Version xx:
+-"Dinner with Thalantyr": Thalantyr should take the knights-errand if he offers to make a magic item out of the bishop piece.
+-Dinner dialogue didn't check for timer.
+
 Version 13:
 -Messenger 2: sort all journal entries into journal for EE
 -No Regrets: correct text format for German version

--- a/bg1re/setup-bg1re.tp2
+++ b/bg1re/setup-bg1re.tp2
@@ -7,7 +7,7 @@ BACKUP ~bg1re/backup~
 AUTHOR ~Please post in the G3 forum for help, refer to readme.~ //for bugreports
 
 //MODDER
-VERSION ~13~
+VERSION ~13.xpre~
 
 README ~bg1re/bg1re.readme.%LANGUAGE%.txt~ ~bg1re/bg1re.readme.english.txt~
 

--- a/bg1re/thalantyr/c#_thalantyr.d
+++ b/bg1re/thalantyr/c#_thalantyr.d
@@ -327,6 +327,8 @@ SAY @327
 IF ~~ THEN DO ~SetGlobal("C#LC_ThalantyrAsked","GLOBAL",16) SetGlobalTimer("C#LC_ThalantyrChessTimer","GLOBAL",ONE_DAY) 
 ActionOverride("Thalantyr",TakePartyItem("c#lcthbs")) 
 ActionOverride("Thalantyr",DestroyItem("c#lcthbs"))
+ActionOverride("Thalantyr",TakePartyItem("c#lcthke"))
+ActionOverride("Thalantyr",DestroyItem("c#lcthke"))
 %ERASEJOURNALENTRY_307%
 %ERASEJOURNALENTRY_283%~ %UNSOLVED_JOURNAL% @328 EXIT
 END
@@ -1028,8 +1030,7 @@ SetGlobal("C#LC_ThalantyrAsked","GLOBAL",5) SetGlobalTimer("C#LC_ThalantyrTimer"
 APPEND %tutu_var%THALAN
 
 IF WEIGHT #-1
-~
-//GlobalTimerExpired("C#LC_ThalantyrTimer","GLOBAL") 
+~GlobalTimerExpired("C#LC_ThalantyrTimer","GLOBAL") 
 Global("C#LC_ThalantyrAsked","GLOBAL",5)~ THEN dinner
 SAY @82
 = @83


### PR DESCRIPTION
-"Dinner with Thalantyr": Thalantyr should take the knights-errand if he offers to make a magic item out of the bishop piece. -Dinner dialogue didn't check for timer.